### PR TITLE
修改standard_log_key

### DIFF
--- a/coding/deeplog/lib/execution_path_detect.py
+++ b/coding/deeplog/lib/execution_path_detect.py
@@ -14,7 +14,7 @@ def standard_log_key(log_key_sequence_str):
     tokens = [int(i) for i in tokens]
     K = max(tokens)+1  # 日志键的种类个数
     # print("the tokens are:",tokens)
-    bigramfdist_4 = FreqDist()
+    # bigramfdist_4 = FreqDist()
     bigrams_4 = ngrams(tokens, 4)
     # from nltk.util import ngrams
     # a = ['1', '2', '3', '4', '5']
@@ -26,10 +26,11 @@ def standard_log_key(log_key_sequence_str):
     # ('2', '3')
     # ('3', '4')
     # ('4', '5')
-    bigramfdist_4.update(bigrams_4)
-    print("the bigramfdsit_4 is:", list(bigramfdist_4.keys()))
+    # bigramfdist_4.update(bigrams_4)
+    # print("the bigramfdsit_4 is:", list(bigramfdist_4.keys()))
     # we set the length of history logs as 3
-    seq = np.array(list(bigramfdist_4.keys()))
+    # seq = np.array(list(bigramfdist_4.keys()))
+    seq = np.array(list(bigrams_4))
 
     # print("the seq is:",seq)
     X, Y = seq[:, :3], seq[:, 3:4]


### PR DESCRIPTION
Hi大佬，我是一名汽车行业的工程师，学习过程中学习到了您这个仓库。日志异常检测我认为在**训练**和**预测**时应该使用全量日志，而不应该去掉重复的序列。所以我注释掉了`bigramfdist_4` 的使用，它会去重`bigrams_4 = ngrams(tokens, 4)`的内容，请您斟酌下是否合理。

喜洋